### PR TITLE
优化含中文的大文件的导入速度

### DIFF
--- a/platforms/android/app/src/main/java/com/noname/shijian/Utils.java
+++ b/platforms/android/app/src/main/java/com/noname/shijian/Utils.java
@@ -8,6 +8,10 @@ import java.io.InputStream;
 
 public class Utils {
 
+    public interface ByteCallback{
+        void onProgress(long bytes);
+    }
+
     public static String getRandomString(int length){
         String pool = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
         char[] cs = new char[length];
@@ -15,6 +19,30 @@ public class Utils {
             cs[i] = pool.charAt((int)(Math.random()*pool.length()));
         }
         return new String(cs);
+    }
+
+    public static void inputStreamToFile(InputStream inputStream,File file,long unit,ByteCallback callback) throws Exception{
+        if(file.exists()){
+            file.delete();
+        }
+        byte[] buffer = new byte[4096];
+        int readLength = -1;
+        FileOutputStream fos = new FileOutputStream(file);
+        long totalLength = 0;
+        long part = 0;
+        while ((readLength = inputStream.read(buffer))!=-1){
+            fos.write(buffer,0,readLength);
+            totalLength += readLength;
+            long newPart = totalLength/unit;
+            if(newPart != part){
+                part = newPart;
+                if(callback!=null){
+                    callback.onProgress(totalLength);
+                }
+            }
+        }
+        fos.close();
+        inputStream.close();
     }
 
     public static void inputStreamToFile(InputStream inputStream,File file) throws Exception{


### PR DESCRIPTION
1、优化包含中文的大文件的导入速度，防止因为频繁的调用zipFile.renameFile，导致导入进度奇慢的问题。
2、在初次加载导入文件时，实时显示已经加载的大小，防止用户以为卡死。
3、在导入进度条下加入随机的提示语，防止导入时用户过于无聊。